### PR TITLE
-Sisyphus#6666 Removal of Function

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -80,14 +80,6 @@ AddEventHandler('hud:client:givestamina', function()
     end
 end)
 
-
-function foo(n)
-    return string.format("%.1f", n / 10^8)
-end
-
-
-
-
 -- Player HUD
 CreateThread(function()
     while true do


### PR DESCRIPTION
Function no longer necessary for calculations of temperature. This was part of the old metabolism code used for translating the Native to a round number, but with the new changes it is no longer necesary.